### PR TITLE
Check for server name with a regexp rather than string eq 

### DIFF
--- a/cbstream.pl
+++ b/cbstream.pl
@@ -105,7 +105,7 @@ sub JoinCBStreamLogin
 {
     my $info = shift;
 
-    if (lc Xchat::get_info('network') eq 'freenode')
+    if (lc Xchat::get_info('network') =~ 'freenode')
     {
         if ($info->[1] eq '#cbstream-login')
         {


### PR DESCRIPTION
As some servers have extra text in the name they report (e.g. "Ubuntu Servers (freenode)".